### PR TITLE
fixes to support `LOGLEVEL` env var

### DIFF
--- a/shib/cli.py
+++ b/shib/cli.py
@@ -35,7 +35,7 @@ REGION:     defaults to us-east-1. AWS region to get credentials for
 IDPURL:     defaults to http://aws.cloud.upenn.edu, the entry into the
             web auth for saml assertions to log into the AWS console as
             a federated user.
-DEBUG:      Used to spit out some additional debugging information, in
+LOGLEVEL:   Used to spit out some additional debugging information, in
             case things aren't working right.
 
 Argument parser values are also available from the --help command.
@@ -134,9 +134,9 @@ def main():
         ' If unset COOKIEJAR environment variables will be used,'
         ' otherwise, ~/.aws-federated-auth.cookies')
     parser.add_argument('--logging',
-        help='Set log level. IF DEBUG environment value set, use that.'
+        help='Set log level. IF LOGLEVEL environment value set, use that.'
         ' otherwise, "INFO"',
-        choices=['critical', 'warning', 'error','info','debug'])
+        choices=['critical', 'warning', 'error', 'info', 'debug'])
     parser.add_argument('--duration',
         help='Duration before timeout of session in seconds.'
         ' Defaults to 1 hour / {0} seconds, min {1} max 12 hours / {2} '
@@ -155,16 +155,15 @@ def main():
     args = parser.parse_args()
     # Variables
 
-    # set DEBUG to enable debug logging
-    #logging.basicConfig(level=logging.INFO)
     level = None
     if args.logging:
         log_level = args.logging.upper()
         level = logging.getLevelName(args.logging.upper())
+        logger.setLevel(level)
+    elif os.environ.get("LOGLEVEL") and os.environ.get("LOGLEVEL") in ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"]:
+        log_level = os.environ.get("LOGLEVEL")
     else:
         log_level = 'INFO'
-    if level:
-        logger.setLevel(level)
 
     if args.list:
         logger.debug("Selected to only list results, rather than"


### PR DESCRIPTION
Advertised environment variable for logging was nonop