### PR TITLE
Add ability to use as credentials process

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ aws-federated-auth --duration 1200
 
 ```
 
+## Using as AWS credential_process
+
+Configure in `~/.aws/config`:
+
+```ini
+[profile my-profile]
+credential_process = aws-federated-auth --credential-process --account <account-number> --rolename <role-name> --user <username>
+```
+
 ## Create binary version
 Included is a sample spec file for generating a single file distribution.
 If your use case isn't one that works with pip installs you can repackage to meet your needs.

--- a/shib/ecpshib.py
+++ b/shib/ecpshib.py
@@ -18,6 +18,7 @@ __version__ = "1.0.1"
 
 #Requirements for Shib Processing
 import os
+import sys
 import logging
 import requests
 import pickle
@@ -171,7 +172,8 @@ class ECPShib(object):
                 if self.duo_factor:
                     headers["X-Shibboleth-Duo-Factor"] = self.duo_factor
                 if self.duo_factor == "passcode":
-                    duo_passcode = input('Code:')
+                    print('Code:', end=' ', file=sys.stderr)
+                    duo_passcode = input()
                     headers["X-Shibboleth-Duo-Passcode"] = duo_passcode
                 auth = (self.username, self.password)
                 logger.debug(f"Precall cookies: {self.session.cookies}")
@@ -197,7 +199,7 @@ class ECPShib(object):
                     )
                     # if a bad username/password was entered, print a message to the user and exit(1)
                     if status is not None and 'status:AuthnFailed' in status.attrib['Value']:
-                        print("Authentication Failed, exiting, nothing done")
+                        print("Authentication Failed, exiting, nothing done", file=sys.stderr)
                         exit(1)
                     #logger.debug(f"Status {status.attrib['Value']}")
                     logger.debug("Authenticated Successfully")


### PR DESCRIPTION
See https://docs.aws.amazon.com/sdkref/latest/guide/feature-process-credentials.html

This avoids writing credentials to disk and integrates with external tools such as [Granted.dev](https://granted.dev/) and [aws-vault](https://github.com/99designs/aws-vault).

Requires moving some output to stderr because stdout needs to only output JSON.

I'm not sure what the workflow is here, so I branched off the version I was told to use, but can switch to `main` if that's preferred.